### PR TITLE
PCF8523: Add additional registers

### DIFF
--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -101,6 +101,15 @@ class PCF8523:
     battery_low = i2c_bit.ROBit(0x02, 2)
     """True if the battery is low and should be replaced."""
 
+    cap_sel = i2c_bit.RWBit(0x00, 7)
+    """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
+
+    calibration_mode = i2c_bit.RWBit(0x0e, 7)
+    """False to offset every 2 hours (1 LSB = 4.340ppm); True to offset every minute (1 LSB = 4.069ppm).  The factory default, False, consumes less power"""
+
+    calibration = i2c_bits.RWBits(7, 0xe, 0, signed=True)
+    """Calibration offset to apply, from -64 to +63.  See the PCF8523 datasheet figure 18 for the offset calibration calculation workflow."""
+
     def __init__(self, i2c_bus):
         self.i2c_device = I2CDevice(i2c_bus, 0x68)
 

--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -104,7 +104,7 @@ class PCF8523:
     high_capacitance = i2c_bit.RWBit(0x00, 7)
     """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
 
-    calibration_schedule_every_minute = i2c_bit.RWBit(0x0E, 7)
+    calibration_schedule_per_minute = i2c_bit.RWBit(0x0E, 7)
     """False to apply the calibration offset every 2 hours (1 LSB = 4.340ppm);
     True to offset every minute (1 LSB = 4.069ppm).  The default, False,
     consumes less power.  See datasheet figures 28-31 for details."""

--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -104,9 +104,10 @@ class PCF8523:
     high_capacitance = i2c_bit.RWBit(0x00, 7)
     """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
 
-    calibration_mode = i2c_bit.RWBit(0x0E, 7)
-    """False to offset every 2 hours (1 LSB = 4.340ppm); True to offset every
-    minute (1 LSB = 4.069ppm).  The default, False, consumes less power"""
+    calibration_schedule_every_minute = i2c_bit.RWBit(0x0E, 7)
+    """False to apply the calibration offset every 2 hours (1 LSB = 4.340ppm);
+    True to offset every minute (1 LSB = 4.069ppm).  The default, False,
+    consumes less power.  See datasheet figures 28-31 for details."""
 
     calibration = i2c_bits.RWBits(7, 0xE, 0, signed=True)
     """Calibration offset to apply, from -64 to +63.  See the PCF8523 datasheet

--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -105,10 +105,12 @@ class PCF8523:
     """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
 
     calibration_mode = i2c_bit.RWBit(0x0E, 7)
-    """False to offset every 2 hours (1 LSB = 4.340ppm); True to offset every minute (1 LSB = 4.069ppm).  The factory default, False, consumes less power"""
+    """False to offset every 2 hours (1 LSB = 4.340ppm); True to offset every
+    minute (1 LSB = 4.069ppm).  The default, False, consumes less power"""
 
     calibration = i2c_bits.RWBits(7, 0xE, 0, signed=True)
-    """Calibration offset to apply, from -64 to +63.  See the PCF8523 datasheet figure 18 for the offset calibration calculation workflow."""
+    """Calibration offset to apply, from -64 to +63.  See the PCF8523 datasheet
+    figure 18 for the offset calibration calculation workflow."""
 
     def __init__(self, i2c_bus):
         self.i2c_device = I2CDevice(i2c_bus, 0x68)

--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -104,10 +104,10 @@ class PCF8523:
     cap_sel = i2c_bit.RWBit(0x00, 7)
     """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
 
-    calibration_mode = i2c_bit.RWBit(0x0e, 7)
+    calibration_mode = i2c_bit.RWBit(0x0E, 7)
     """False to offset every 2 hours (1 LSB = 4.340ppm); True to offset every minute (1 LSB = 4.069ppm).  The factory default, False, consumes less power"""
 
-    calibration = i2c_bits.RWBits(7, 0xe, 0, signed=True)
+    calibration = i2c_bits.RWBits(7, 0xE, 0, signed=True)
     """Calibration offset to apply, from -64 to +63.  See the PCF8523 datasheet figure 18 for the offset calibration calculation workflow."""
 
     def __init__(self, i2c_bus):

--- a/adafruit_pcf8523.py
+++ b/adafruit_pcf8523.py
@@ -101,7 +101,7 @@ class PCF8523:
     battery_low = i2c_bit.ROBit(0x02, 2)
     """True if the battery is low and should be replaced."""
 
-    cap_sel = i2c_bit.RWBit(0x00, 7)
+    high_capacitance = i2c_bit.RWBit(0x00, 7)
     """True for high oscillator capacitance (12.5pF), otherwise lower (7pF)"""
 
     calibration_mode = i2c_bit.RWBit(0x0E, 7)


### PR DESCRIPTION
This adds the following registers:
 * cap_sel, True to add additional capacitance to clock pins
 * calibration_mode, select one of two different clock calibration methods
 * calibration, set the clock calibration (offset) value in ~4ppm steps

By accurately measuring the crystal frequency, these values can be selected to improve the calibration of the RTC from "minutes per month" to "seconds per month".

This depends on https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/39 as the "calibration" register holds a signed value, so it should not be accepted until that PR is accepted.